### PR TITLE
Update example DAGs with authoring best practices

### DIFF
--- a/examples/airflow/dags/etl/etl_categories.py
+++ b/examples/airflow/dags/etl/etl_categories.py
@@ -1,31 +1,33 @@
+from pendulum import datetime
+
 from airflow import DAG
-from airflow.utils.dates import days_ago
 from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
+
 
 SNOWFLAKE_WAREHOUSE = 'COMPUTE_WH'
 SNOWFLAKE_DATABASE = 'OPENLINEAGE'
 
-default_args = {
-    'owner': 'openlineage',
-    'depends_on_past': False,
-    'start_date': days_ago(1),
-    'email_on_failure': False,
-    'email_on_retry': False,
-    'email': ['demo@openlineage.io'],
-    'snowflake_conn_id': 'openlineage_snowflake'
-}
 
-with DAG('etl_categories',
-         schedule_interval='@daily',
-         catchup=False,
-         default_args=default_args,
-         description='Loads newly added menu categories.') as dag:
+with DAG(
+    'etl_categories',
+    start_date=datetime(2022, 4, 12),
+    schedule_interval='@daily',
+    catchup=False,
+    default_args={
+        'owner': 'openlineage',
+        'depends_on_past': False,
+        'email_on_failure': False,
+        'email_on_retry': False,
+        'email': ['demo@openlineage.io'],
+        'snowflake_conn_id': 'openlineage_snowflake',
+        'warehouse': SNOWFLAKE_WAREHOUSE,
+        'database': SNOWFLAKE_DATABASE,
+    },
+    description='Loads newly added menu categories.',
+) as dag:
 
     t1 = SnowflakeOperator(
         task_id='if_not_exists',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         CREATE TABLE IF NOT EXISTS food_delivery.categories (
             id          INTEGER,
@@ -38,9 +40,6 @@ with DAG('etl_categories',
 
     t2 = SnowflakeOperator(
         task_id='etl',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         INSERT INTO food_delivery.categories (id, name, menu_id, description)
         SELECT id, name, menu_id, description

--- a/examples/airflow/dags/etl/etl_customers.py
+++ b/examples/airflow/dags/etl/etl_customers.py
@@ -1,31 +1,33 @@
+from pendulum import datetime
+
 from airflow import DAG
-from airflow.utils.dates import days_ago
 from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
+
 
 SNOWFLAKE_WAREHOUSE = 'COMPUTE_WH'
 SNOWFLAKE_DATABASE = 'OPENLINEAGE'
 
-default_args = {
-    'owner': 'openlineage',
-    'depends_on_past': False,
-    'start_date': days_ago(1),
-    'email_on_failure': False,
-    'email_on_retry': False,
-    'email': ['demo@openlineage.io'],
-    'snowflake_conn_id': 'openlineage_snowflake'
-}
 
-with DAG('etl_customers',
-         schedule_interval='@daily',
-         catchup=False,
-         default_args=default_args,
-         description='Loads newly registered customers.') as dag:
+with DAG(
+    'etl_customers',
+    start_date=datetime(2022, 4, 12),
+    schedule_interval='@daily',
+    catchup=False,
+    default_args={
+        'owner': 'openlineage',
+        'depends_on_past': False,
+        'email_on_failure': False,
+        'email_on_retry': False,
+        'email': ['demo@openlineage.io'],
+        'snowflake_conn_id': 'openlineage_snowflake',
+        'warehouse': SNOWFLAKE_WAREHOUSE,
+        'database': SNOWFLAKE_DATABASE,
+    },
+    description='Loads newly registered customers.',
+) as dag:
 
     t1 = SnowflakeOperator(
         task_id='if_not_exists',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         CREATE TABLE IF NOT EXISTS food_delivery.customers (
             id         INTEGER,
@@ -42,9 +44,6 @@ with DAG('etl_customers',
 
     t2 = SnowflakeOperator(
         task_id='etl',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         INSERT INTO food_delivery.customers (id, created_at, updated_at, name, email, address, phone, city_id)
         SELECT id, created_at, updated_at, name, email, address, phone, city_id

--- a/examples/airflow/dags/etl/etl_drivers.py
+++ b/examples/airflow/dags/etl/etl_drivers.py
@@ -1,31 +1,33 @@
+from pendulum import datetime
+
 from airflow import DAG
-from airflow.utils.dates import days_ago
 from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
+
 
 SNOWFLAKE_WAREHOUSE = 'COMPUTE_WH'
 SNOWFLAKE_DATABASE = 'OPENLINEAGE'
 
-default_args = {
-    'owner': 'openlineage',
-    'depends_on_past': False,
-    'start_date': days_ago(1),
-    'email_on_failure': False,
-    'email_on_retry': False,
-    'email': ['demo@openlineage.io'],
-    'snowflake_conn_id': 'openlineage_snowflake'
-}
 
-with DAG('etl_drivers',
-         schedule_interval='@daily',
-         catchup=False,
-         default_args=default_args,
-         description='Loads newly registered drivers.') as dag:
+with DAG(
+    'etl_drivers',
+    start_date=datetime(2022, 4, 12),
+    schedule_interval='@daily',
+    catchup=False,
+    default_args={
+        'owner': 'openlineage',
+        'depends_on_past': False,
+        'email_on_failure': False,
+        'email_on_retry': False,
+        'email': ['demo@openlineage.io'],
+        'snowflake_conn_id': 'openlineage_snowflake',
+        'warehouse': SNOWFLAKE_WAREHOUSE,
+        'database': SNOWFLAKE_DATABASE,
+    },
+    description='Loads newly registered drivers.',
+) as dag:
 
     t1 = SnowflakeOperator(
         task_id='if_not_exists',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         CREATE TABLE IF NOT EXISTS food_delivery.drivers (
             id                INTEGER,
@@ -45,9 +47,6 @@ with DAG('etl_drivers',
 
     t2 = SnowflakeOperator(
         task_id='etl',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         INSERT INTO food_delivery.drivers (
             id,

--- a/examples/airflow/dags/etl/etl_menu_items.py
+++ b/examples/airflow/dags/etl/etl_menu_items.py
@@ -1,31 +1,33 @@
+from pendulum import datetime
+
 from airflow import DAG
-from airflow.utils.dates import days_ago
 from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
+
 
 SNOWFLAKE_WAREHOUSE = 'COMPUTE_WH'
 SNOWFLAKE_DATABASE = 'OPENLINEAGE'
 
-default_args = {
-    'owner': 'openlineage',
-    'depends_on_past': False,
-    'start_date': days_ago(1),
-    'email_on_failure': False,
-    'email_on_retry': False,
-    'email': ['demo@openlineage.io'],
-    'snowflake_conn_id': 'openlineage_snowflake'
-}
 
-with DAG('etl_menu_items',
-         schedule_interval='@daily',
-         catchup=False,
-         default_args=default_args,
-         description='Loads newly added restaurant menu items') as dag:
+with DAG(
+    'etl_menu_items',
+    start_date=datetime(2022, 4, 12),
+    schedule_interval='@daily',
+    catchup=False,
+    default_args={
+        'owner': 'openlineage',
+        'depends_on_past': False,
+        'email_on_failure': False,
+        'email_on_retry': False,
+        'email': ['demo@openlineage.io'],
+        'snowflake_conn_id': 'openlineage_snowflake',
+        'warehouse': SNOWFLAKE_WAREHOUSE,
+        'database': SNOWFLAKE_DATABASE,
+    },
+    description='Loads newly added restaurant menu items.',
+) as dag:
 
     t1 = SnowflakeOperator(
         task_id='if_not_exists',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         CREATE TABLE IF NOT EXISTS food_delivery.menu_items (
             id          INTEGER,
@@ -39,9 +41,6 @@ with DAG('etl_menu_items',
 
     t2 = SnowflakeOperator(
         task_id='etl',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         INSERT INTO food_delivery.menu_items (id, name, price, category_id, description)
         SELECT id, name, price, category_id, description

--- a/examples/airflow/dags/etl/etl_menus.py
+++ b/examples/airflow/dags/etl/etl_menus.py
@@ -1,31 +1,33 @@
+from pendulum import datetime
+
 from airflow import DAG
-from airflow.utils.dates import days_ago
 from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
+
 
 SNOWFLAKE_WAREHOUSE = 'COMPUTE_WH'
 SNOWFLAKE_DATABASE = 'OPENLINEAGE'
 
-default_args = {
-    'owner': 'openlineage',
-    'depends_on_past': False,
-    'start_date': days_ago(1),
-    'email_on_failure': False,
-    'email_on_retry': False,
-    'email': ['demo@openlineage.io'],
-    'snowflake_conn_id': 'openlineage_snowflake'
-}
 
-with DAG('etl_menus',
-         schedule_interval='@daily',
-         catchup=False,
-         default_args=default_args,
-         description='Loads newly added restaurant menus') as dag:
+with DAG(
+    'etl_menus',
+    start_date=datetime(2022, 4, 12),
+    schedule_interval='@daily',
+    catchup=False,
+    default_args={
+        'owner': 'openlineage',
+        'depends_on_past': False,
+        'email_on_failure': False,
+        'email_on_retry': False,
+        'email': ['demo@openlineage.io'],
+        'snowflake_conn_id': 'openlineage_snowflake',
+        'warehouse': SNOWFLAKE_WAREHOUSE,
+        'database': SNOWFLAKE_DATABASE,
+    },
+    description='Loads newly added restaurant menus.',
+) as dag:
 
     t1 = SnowflakeOperator(
         task_id='if_not_exists',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         CREATE TABLE IF NOT EXISTS food_delivery.menus (
             id            INTEGER,
@@ -38,9 +40,6 @@ with DAG('etl_menus',
 
     t2 = SnowflakeOperator(
         task_id='etl',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         INSERT INTO food_delivery.menus (id, name, restaurant_id, description)
         SELECT id, name, restaurant_id, description

--- a/examples/airflow/dags/etl/etl_new_deliveries.py
+++ b/examples/airflow/dags/etl/etl_new_deliveries.py
@@ -1,31 +1,34 @@
+from pendulum import datetime
+
 from airflow import DAG
-from airflow.utils.dates import days_ago
 from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
+
 
 SNOWFLAKE_WAREHOUSE = 'COMPUTE_WH'
 SNOWFLAKE_DATABASE = 'OPENLINEAGE'
 
-default_args = {
-    'owner': 'openlineage',
-    'depends_on_past': False,
-    'start_date': days_ago(1),
-    'email_on_failure': False,
-    'email_on_retry': False,
-    'email': ['demo@openlineage.io'],
-    'snowflake_conn_id': 'openlineage_snowflake'
-}
 
-with DAG('etl_new_delivery',
-         schedule_interval='@daily',
-         catchup=False,
-         default_args=default_args,
-         description='Add new food delivery data.') as dag:
+with DAG(
+    'etl_new_delivery',
+    start_date=datetime(2022, 4, 12),
+    schedule_interval='@daily',
+    catchup=False,
+    default_args={
+        'owner': 'openlineage',
+        'depends_on_past': False,
+        'start_date': days_ago(1),
+        'email_on_failure': False,
+        'email_on_retry': False,
+        'email': ['demo@openlineage.io'],
+        'snowflake_conn_id': 'openlineage_snowflake',
+        'warehouse': SNOWFLAKE_WAREHOUSE,
+        'database': SNOWFLAKE_DATABASE,
+    },
+    description='Add new food delivery data.',
+) as dag:
 
     t1 = SnowflakeOperator(
         task_id='if_not_exists_cities',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         CREATE TABLE IF NOT EXISTS food_delivery.cities (
             id       INTEGER,
@@ -38,9 +41,6 @@ with DAG('etl_new_delivery',
 
     t2 = SnowflakeOperator(
         task_id='if_not_exists_business_hours',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         CREATE TABLE IF NOT EXISTS food_delivery.business_hours (
             id          INTEGER,
@@ -53,9 +53,6 @@ with DAG('etl_new_delivery',
 
     t3 = SnowflakeOperator(
         task_id='if_not_exists_discounts',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         CREATE TABLE IF NOT EXISTS food_delivery.discounts (
             id           INTEGER,
@@ -69,9 +66,6 @@ with DAG('etl_new_delivery',
 
     t4 = SnowflakeOperator(
         task_id='if_not_exists_tmp_restaurants',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         CREATE TABLE IF NOT EXISTS food_delivery.tmp_restaurants (
             id                INTEGER,
@@ -90,9 +84,6 @@ with DAG('etl_new_delivery',
 
     t5 = SnowflakeOperator(
         task_id='if_not_exists_tmp_menus',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         CREATE TABLE IF NOT EXISTS food_delivery.tmp_menus (
             id            INTEGER,
@@ -105,9 +96,6 @@ with DAG('etl_new_delivery',
 
     t6 = SnowflakeOperator(
         task_id='if_not_exists_tmp_menu_items',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         CREATE TABLE IF NOT EXISTS food_delivery.tmp_menu_items (
             id          INTEGER,
@@ -121,9 +109,6 @@ with DAG('etl_new_delivery',
 
     t7 = SnowflakeOperator(
         task_id='if_not_exists_tmp_categories',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         CREATE TABLE IF NOT EXISTS food_delivery.tmp_categories (
             id          INTEGER,
@@ -136,9 +121,6 @@ with DAG('etl_new_delivery',
 
     t8 = SnowflakeOperator(
         task_id='if_not_exists_tmp_drivers',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         CREATE TABLE IF NOT EXISTS food_delivery.tmp_drivers (
             id                INTEGER,
@@ -158,9 +140,6 @@ with DAG('etl_new_delivery',
 
     t9 = SnowflakeOperator(
         task_id='if_not_exists_tmp_customers',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         CREATE TABLE IF NOT EXISTS food_delivery.tmp_customers (
             id         INTEGER,
@@ -177,9 +156,6 @@ with DAG('etl_new_delivery',
 
     t10 = SnowflakeOperator(
         task_id='if_not_exists_tmp_orders',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         CREATE TABLE IF NOT EXISTS food_delivery.tmp_orders (
             id           INTEGER,
@@ -194,9 +170,6 @@ with DAG('etl_new_delivery',
 
     t11 = SnowflakeOperator(
         task_id='if_not_exists_tmp_order_status',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         CREATE TABLE IF NOT EXISTS food_delivery.tmp_order_status (
             id              INTEGER,

--- a/examples/airflow/dags/etl/etl_order_7_days.py
+++ b/examples/airflow/dags/etl/etl_order_7_days.py
@@ -1,31 +1,33 @@
+from pendulum import datetime
+
 from airflow import DAG
-from airflow.utils.dates import days_ago
 from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
+
 
 SNOWFLAKE_WAREHOUSE = 'COMPUTE_WH'
 SNOWFLAKE_DATABASE = 'OPENLINEAGE'
 
-default_args = {
-    'owner': 'openlineage',
-    'depends_on_past': False,
-    'start_date': days_ago(1),
-    'email_on_failure': False,
-    'email_on_retry': False,
-    'email': ['demo@openlineage.io'],
-    'snowflake_conn_id': 'openlineage_snowflake'
-}
 
-with DAG('etl_order_7_days',
-         schedule_interval='@weekly',
-         catchup=False,
-         default_args=default_args,
-         description='Loads placed orders weekly.') as dag:
+with DAG(
+    'etl_order_7_days',
+    start_date=datetime(2022, 4, 12),
+    schedule_interval='@weekly',
+    catchup=False,
+    default_args={
+        'owner': 'openlineage',
+        'depends_on_past': False,
+        'email_on_failure': False,
+        'email_on_retry': False,
+        'email': ['demo@openlineage.io'],
+        'snowflake_conn_id': 'openlineage_snowflake',
+        'warehouse': SNOWFLAKE_WAREHOUSE,
+        'database': SNOWFLAKE_DATABASE,
+    },
+    description='Loads placed orders weekly.',
+) as dag:
 
     t1 = SnowflakeOperator(
         task_id='if_not_exists_orders_7_days',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         CREATE TABLE IF NOT EXISTS food_delivery.orders_7_days (
             order_id      INTEGER,
@@ -41,9 +43,6 @@ with DAG('etl_order_7_days',
 
     t2 = SnowflakeOperator(
         task_id='insert',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         INSERT INTO food_delivery.orders_7_days (
             order_id,
@@ -68,7 +67,7 @@ with DAG('etl_order_7_days',
                        ON c.id = mi.category_id
                inner join food_delivery.menus AS m
                        ON m.id = c.menu_id
-        WHERE  o.placed_on >= TIMEADD(hour, -168, current_time())  
+        WHERE  o.placed_on >= TIMEADD(hour, -168, current_time())
         ''',
         session_parameters={
             'QUERY_TAG': 'etl_order_7_days'

--- a/examples/airflow/dags/etl/etl_order_status.py
+++ b/examples/airflow/dags/etl/etl_order_status.py
@@ -1,31 +1,33 @@
+from pendulum import datetime
+
 from airflow import DAG
-from airflow.utils.dates import days_ago
 from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
+
 
 SNOWFLAKE_WAREHOUSE = 'COMPUTE_WH'
 SNOWFLAKE_DATABASE = 'OPENLINEAGE'
 
-default_args = {
-    'owner': 'openlineage',
-    'depends_on_past': False,
-    'start_date': days_ago(1),
-    'email_on_failure': False,
-    'email_on_retry': False,
-    'email': ['demo@openlineage.io'],
-    'snowflake_conn_id': 'openlineage_snowflake'
-}
 
-with DAG('etl_order_status',
-         schedule_interval='@daily',
-         catchup=False,
-         default_args=default_args,
-         description='Loads order status updates.') as dag:
+with DAG(
+    'etl_order_status',
+    start_date=datetime(2022, 4, 12),
+    schedule_interval='@daily',
+    catchup=False,
+    default_args={
+        'owner': 'openlineage',
+        'depends_on_past': False,
+        'email_on_failure': False,
+        'email_on_retry': False,
+        'email': ['demo@openlineage.io'],
+        'snowflake_conn_id': 'openlineage_snowflake',
+        'warehouse': SNOWFLAKE_WAREHOUSE,
+        'database': SNOWFLAKE_DATABASE,
+    },
+    description='Loads order status updates.',
+) as dag:
 
     t1 = SnowflakeOperator(
         task_id='if_not_exists',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         CREATE TABLE IF NOT EXISTS food_delivery.order_status (
             id              INTEGER,
@@ -41,9 +43,6 @@ with DAG('etl_order_status',
 
     t2 = SnowflakeOperator(
         task_id='etl',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         INSERT INTO food_delivery.order_status (
             id,

--- a/examples/airflow/dags/etl/etl_orders.py
+++ b/examples/airflow/dags/etl/etl_orders.py
@@ -1,31 +1,33 @@
+from pendulum import datetime
+
 from airflow import DAG
-from airflow.utils.dates import days_ago
 from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
+
 
 SNOWFLAKE_WAREHOUSE = 'COMPUTE_WH'
 SNOWFLAKE_DATABASE = 'OPENLINEAGE'
 
-default_args = {
-    'owner': 'openlineage',
-    'depends_on_past': False,
-    'start_date': days_ago(1),
-    'email_on_failure': False,
-    'email_on_retry': False,
-    'email': ['demo@openlineage.io'],
-    'snowflake_conn_id': 'openlineage_snowflake'
-}
 
-with DAG('etl_orders',
-         schedule_interval='@daily',
-         catchup=False,
-         default_args=default_args,
-         description='Loads newly placed orders.') as dag:
+with DAG(
+    'etl_orders',
+    start_date=datetime(2022, 4, 12),
+    schedule_interval='@daily',
+    catchup=False,
+    default_args={
+        'owner': 'openlineage',
+        'depends_on_past': False,
+        'email_on_failure': False,
+        'email_on_retry': False,
+        'email': ['demo@openlineage.io'],
+        'snowflake_conn_id': 'openlineage_snowflake',
+        'warehouse': SNOWFLAKE_WAREHOUSE,
+        'database': SNOWFLAKE_DATABASE,
+    },
+    description='Loads newly placed orders.',
+) as dag:
 
     t1 = SnowflakeOperator(
         task_id='if_not_exists',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         CREATE TABLE IF NOT EXISTS food_delivery.orders (
             id           INTEGER,
@@ -40,9 +42,6 @@ with DAG('etl_orders',
 
     t2 = SnowflakeOperator(
         task_id='etl',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         INSERT INTO food_delivery.orders (id, placed_on, menu_item_id, quantity, discount_id, comment)
         SELECT id, placed_on, menu_item_id, quantity, discount_id, comment

--- a/examples/airflow/dags/etl/etl_restaurants.py
+++ b/examples/airflow/dags/etl/etl_restaurants.py
@@ -1,31 +1,33 @@
+from pendulum import datetime
+
 from airflow import DAG
-from airflow.utils.dates import days_ago
 from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
+
 
 SNOWFLAKE_WAREHOUSE = 'COMPUTE_WH'
 SNOWFLAKE_DATABASE = 'OPENLINEAGE'
 
-default_args = {
-    'owner': 'openlineage',
-    'depends_on_past': False,
-    'start_date': days_ago(1),
-    'email_on_failure': False,
-    'email_on_retry': False,
-    'email': ['demo@openlineage.io'],
-    'snowflake_conn_id': 'openlineage_snowflake'
-}
 
-with DAG('etl_restaurants',
-         schedule_interval='@daily',
-         catchup=False,
-         default_args=default_args,
-         description='Loads newly registered restaurants') as dag:
+with DAG(
+    'etl_restaurants',
+    start_date=datetime(2022, 4, 12),
+    schedule_interval='@daily',
+    catchup=False,
+    default_args={
+        'owner': 'openlineage',
+        'depends_on_past': False,
+        'email_on_failure': False,
+        'email_on_retry': False,
+        'email': ['demo@openlineage.io'],
+        'snowflake_conn_id': 'openlineage_snowflake',
+        'warehouse': SNOWFLAKE_WAREHOUSE,
+        'database': SNOWFLAKE_DATABASE,
+    },
+    description='Loads newly registered restaurants.',
+) as dag:
 
     t1 = SnowflakeOperator(
         task_id='if_not_exists',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         CREATE TABLE IF NOT EXISTS food_delivery.restaurants (
             id                INTEGER,
@@ -44,9 +46,6 @@ with DAG('etl_restaurants',
 
     t2 = SnowflakeOperator(
         task_id='etl',
-        dag=dag,
-        warehouse=SNOWFLAKE_WAREHOUSE,
-        database=SNOWFLAKE_DATABASE,
         sql='''
         INSERT INTO food_delivery.restaurants (
             id,


### PR DESCRIPTION
These DAGs are very thorough, and there were opportunities to showcase some best practices in DAG authoring with all these wonderful examples (without _really_ having the ability to test as thoroughly).  I have confirmed that these DAGs will render in the Airflow UI however.

Proposing to update the DAGs with various themes namely:
- Using a static `start_date` value.
- Using `pendulum.datetime` instead of `datetime.datetime` for `start_date`.
  - This is mainly for [time-zone-aware DAGs](https://airflow.apache.org/docs/apache-airflow/stable/timezone.html#time-zone-aware-dags) it is good practice to use `pendulum` just in case users do want to make a DAG time zone aware.
- Reduce boilerplate by using `default_args` when tasks share the same arg and value. 
- Declaring `default_args` directly in the `DAG()` instantiation.
  - This is more for readability so users don't have to to re-read what the `default_args` are if declared earlier in a DAG where only 1 DAG object exists.
- Removing the need to assign the `dag` parameter when using the `DAG()` object as context manager.
- Prefer the `@task` decorator over the `PythonOperator`.
 