### PR TITLE
Update .env-example

### DIFF
--- a/examples/airflow/.env-example
+++ b/examples/airflow/.env-example
@@ -1,7 +1,9 @@
 SNOWFLAKE_USER=<your Snowflake user>
 SNOWFLAKE_PASSWORD=<your Snowflake password>
 SNOWFLAKE_ACCOUNT=<your Snowflake account>
-AIRFLOW_CONN_OPENLINEAGE_SNOWFLAKE='snowflake://<your Snowflake user>:<your Snowflake password>@<your Snowflake host>/food_delivery?account=SNOWFLAKE_ACCOUNT=<your Snowflake account>&database=openlineage'
+SNOWFLAKE_HOST=SNOWFLAKE_ACCOUNT.snowflakecomputing.com
+SNOWFLAKE_DB=openlineage
+AIRFLOW_CONN_OPENLINEAGE_SNOWFLAKE="snowflake://$SNOWFLAKE_USER:$SNOWFLAKE_PASSWORD@$SNOWFLAKE_HOST/food_delivery?account=SNOWFLAKE_ACCOUNT=$SNOWFLAKE_ACCOUNT&database=$SNOWFLAKE_DB"
 
 OPENLINEAGE_URL=http://localhost:5000
 


### PR DESCRIPTION
Using variables to make the .env example more intuitive (e.g. you only enter your SNOWFLAKE_USER once, and it's used in the AIRFLOW_CONN_OPENLINEAGE_SNOWFLAKE variable without having to add it in a 2nd time)